### PR TITLE
#41 - add PTM 2.3 info to the site

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,10 +18,21 @@
 
 <h1> Last event </h1>
 
-<h3> The Mainframe Dinossaur </h3>
+<h3> Testing startups vs. consulting - Pedro Glória </h3>
 
-<iframe width="854" height="480" src="https://www.youtube.com/embed/YaThGLN-8Jo" frameborder="0" gesture="media" allowfullscreen style="max-width: -webkit-fill-available;"></iframe>
+<iframe width="854" height="480" src="https://www.youtube.com/embed/Qw1WvmvGBIY" frameborder="0" gesture="media" allowfullscreen style="max-width: -webkit-fill-available;"></iframe>
 
+<h3> From Brazil to Germany: a Short Tester Story - Carolina Batista </h3>
+
+<iframe width="854" height="480" src="https://www.youtube.com/embed/zfzLCcrlpz8" frameborder="0" gesture="media" allowfullscreen style="max-width: -webkit-fill-available;"></iframe>
+
+<h3> How Xing Created a Successful News Platform From Scratch - Maik Nogens </h3>
+
+<iframe width="854" height="480" src="https://www.youtube.com/embed/vajWZcHcvR4" frameborder="0" gesture="media" allowfullscreen style="max-width: -webkit-fill-available;"></iframe>
+
+<h1> Past Events </h1>
+
+You can browse other past events [here](../pages/past_events).
 
 <h1> Team </h1>
 

--- a/pages/past_events.md
+++ b/pages/past_events.md
@@ -1,0 +1,13 @@
+<h1> Past Events </h1>
+
+<center><a href="../index.html"><button type="button">Home</button></a></center>
+<br/>
+
+<h3> The Mainframe Dinossaur </h3>
+
+<iframe width="854" height="480" src="https://www.youtube.com/embed/YaThGLN-8Jo" frameborder="0" gesture="media" allowfullscreen style="max-width: -webkit-fill-available;"></iframe>
+
+<p>This page is still work-in-progress</p>
+
+<br/>
+<center><a href="../index.html"><button type="button">Home</button></a></center>


### PR DESCRIPTION
Related issue: #41 

+ created past_events page, for older events

/cc @filipemcarvalho @FabioCB 

The final result looks like this:
![screen shot 2018-02-01 at 12 01 03](https://user-images.githubusercontent.com/11976836/35677524-df120e18-0747-11e8-9223-6471aae91d05.png)
