### PR TITLE
#31 - Redesign home button in CFS and CFV pages

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -3,6 +3,8 @@
 
 @import "{{ site.theme }}";
 
+$em: 18px;
+
 h1.project-name{
   visibility: hidden;
   font-family: initial;
@@ -95,4 +97,16 @@ h1.project-name:after{
 
 .overlay-link {
   background-color: #e2e2e2;
+}
+
+button {
+  display: inline-block;
+  color: #fff;
+  background-color: #02afe8;
+  border-color: #02afe8;
+  border-style: solid;
+  margin-bottom: $em;
+  margin-right: .4 * $em;
+  padding: .3625 * $em 1.3 * $em;
+  border-radius: .2 * $em;
 }


### PR DESCRIPTION
Related issue: #31 

End result of this PR:

Top of page:
<img width="1237" alt="screen shot 2018-03-18 at 13 00 28" src="https://user-images.githubusercontent.com/11976836/37566143-bc8511be-2aac-11e8-88f0-b7f4ab9f34ec.png">

End of page:
<img width="1061" alt="screen shot 2018-03-18 at 13 00 35" src="https://user-images.githubusercontent.com/11976836/37566134-a3fdd554-2aac-11e8-9e09-9564dbd969c2.png">

/cc @FabioCB @filipemcarvalho 